### PR TITLE
update to the `IafUploadModule` interface 

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ It is meant to run when a file is added to the ingest destination.
 
 `readStream`: a `Readable`stream of the file to upload. Files need to be provided as streams in order keep memory consumption at a reasonable level.
 
-#### `progressDelegate: Function`
+#### `progressDelegate: () => any`
 
 A function that should be injected when constructing an UploadModule instance. This callback should be called whenever the upload progresses. Possible uses are logging and error handling.
 
-#### `fileUploadedDelegate: Function`
+#### `fileUploadedDelegate: () => any`
 
 A callback function that should be injected when instantiating an upload module. The callback is run when the UploadModule has finished uploading the file to the associated transcoding service.
 

--- a/interfaces/interfaces.d.ts
+++ b/interfaces/interfaces.d.ts
@@ -5,8 +5,8 @@ interface IafUploadModule {
     logger: winston.Logger;
     playlistName: string;
     onFileAdd(filePath: string, readStream: Readable, contentType?: string): any;
-    progressDelegate: Function;
-    fileUploadedDelegate: Function;
+    progressDelegate: () => any;
+    fileUploadedDelegate: () => any;
 }
 
 interface IafFileWatchModule {


### PR DESCRIPTION
This PR updates the `IafUploadModule` interface and specifically the `progressDelegate` and `fileUploadedDelegate` to better conform with the interface defined in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/57091.  